### PR TITLE
Fix: Add pause on pip failure in install_python_dependencies

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -471,6 +471,9 @@ class SystemInstaller:
         pip_upgrade_exit_code, pip_upgrade_output = self.run_command(f"{sys.executable} -m pip install --upgrade pip")
         if pip_upgrade_exit_code != 0:
             self.print_step(f"Error actualizando pip (código: {pip_upgrade_exit_code}): {pip_upgrade_output}", "error")
+            if self.is_admin:
+                self.print_step("La ventana se cerrará en 20 segundos...", "info")
+                time.sleep(20)
             return False
         
         # Instalar dependencias del backend
@@ -494,6 +497,9 @@ class SystemInstaller:
             exit_code, output = self.run_command(f"{sys.executable} -m pip install {dep}")
             if exit_code != 0:
                 self.print_step(f"Error instalando {dep} (código: {exit_code}): {output}", "error")
+                if self.is_admin:
+                    self.print_step(f"La instalación de {dep} falló. La ventana se cerrará en 20 segundos...", "info")
+                    time.sleep(20)
                 return False
         
         self.print_step("Dependencias de Python instaladas", "success")


### PR DESCRIPTION
- Modified `install_python_dependencies` to include a 20-second pause (`time.sleep(20)`) if a pip command fails and the script is running with admin privileges.
- This pause occurs after the error message from pip is printed, both for the `pip install --upgrade pip` command and for individual package installations in the dependency loop.
- This change is intended to keep the console window open if a pip error occurs, allowing the user to read and report the specific error message.