### PR TITLE
Fix: Update pydantic version to 2.7.1

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -487,7 +487,7 @@ class SystemInstaller:
             "docker==6.1.3",
             "asyncio",
             "websockets==11.0.3",
-            "pydantic==2.5.0",
+            "pydantic==2.7.1", # Updated from 2.5.0
             "python-multipart==0.0.6",
             "bcrypt==4.1.2",
             "pyjwt==2.8.0"


### PR DESCRIPTION
Updated the pydantic dependency from version 2.5.0 to 2.7.1. This is an attempt to resolve an issue where installing pydantic 2.5.0 on Python 3.13 required a Rust toolchain because pre-built wheels were not available, and the Rust toolchain was missing. Version 2.7.1 is hoped to have better wheel availability for Python 3.13 or a different build process not strictly requiring Rust if wheels are absent.