### PR TITLE
Fix: Downgrade pydantic to 2.6.4 for Python 3.13

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -487,7 +487,7 @@ class SystemInstaller:
             "docker==6.1.3",
             "asyncio",
             "websockets==11.0.3",
-            "pydantic==2.7.1", # Updated from 2.5.0
+            "pydantic==2.6.4", # Downgrading from 2.7.1 to test Python 3.13 compatibility
             "python-multipart==0.0.6",
             "bcrypt==4.1.2",
             "pyjwt==2.8.0"


### PR DESCRIPTION
Attempt to resolve pydantic-core build failure on Python 3.13 by downgrading pydantic from 2.7.1 to 2.6.4.
The PYO3_USE_ABI3_FORWARD_COMPATIBILITY=1 flag remains set.