### PR TITLE
Fix: Downgrade pydantic to 2.5.3 for Python 3.13

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -487,7 +487,7 @@ class SystemInstaller:
             "docker==6.1.3",
             "asyncio",
             "websockets==11.0.3",
-            "pydantic==2.6.4", # Downgrading from 2.7.1 to test Python 3.13 compatibility
+            "pydantic==2.5.3", # Downgrading further to test Python 3.13 compatibility
             "python-multipart==0.0.6",
             "bcrypt==4.1.2",
             "pyjwt==2.8.0"


### PR DESCRIPTION
Further attempt to resolve pydantic-core build failure on Python 3.13 by downgrading pydantic from 2.6.4 to 2.5.3.
The PYO3_USE_ABI3_FORWARD_COMPATIBILITY=1 flag remains set.