### PR TITLE
Fix: Update pydantic to 2.11.7 for Python 3.13 compatibility

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -487,7 +487,7 @@ class SystemInstaller:
             "docker==6.1.3",
             "asyncio",
             "websockets==11.0.3",
-            "pydantic==2.5.3", # Downgrading further to test Python 3.13 compatibility
+            "pydantic==2.11.7", # Updating to latest stable to test Python 3.13 compatibility
             "python-multipart==0.0.6",
             "bcrypt==4.1.2",
             "pyjwt==2.8.0"


### PR DESCRIPTION
Update pydantic to the latest stable version (2.11.7) as an attempt to resolve pydantic-core build failures on Python 3.13. The PYO3_USE_ABI3_FORWARD_COMPATIBILITY=1 flag remains set.