### PR TITLE
Fix UnicodeDecodeError in setup.py by specifying UTF-8 encoding for s…

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -203,6 +203,8 @@ class SystemInstaller:
                     stdout=subprocess.PIPE,
                     stderr=subprocess.STDOUT,
                     text=True,
+                    encoding='utf-8',
+                    errors='replace',
                     check=False
                 )
                 # Check for specific winget "already installed" exit code
@@ -223,6 +225,8 @@ class SystemInstaller:
                         shell=shell,
                         capture_output=True,
                         text=True,
+                        encoding='utf-8',
+                        errors='replace',
                         check=True
                     )
                     return 0, process.stdout.strip() # Success is exit code 0
@@ -232,6 +236,8 @@ class SystemInstaller:
                         shell=shell,
                         capture_output=True,
                         text=True,
+                        encoding='utf-8',
+                        errors='replace',
                         check=False
                     )
                     output_msg = process.stdout.strip() if process.returncode == 0 else \


### PR DESCRIPTION
…ubprocess output

This change modifies the `run_command` function in `setup.py` to use `encoding='utf-8'` and `errors='replace'` when calling `subprocess.run` with `text=True`. This prevents `UnicodeDecodeError` that occurred when processing output from commands like `ollama pull`, which may contain special characters (e.g., progress bars) not compatible with the default system encoding (e.g., cp1252 on Windows).