### PR TITLE
Use absolute path for start.bat in Popen call

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1561,18 +1561,20 @@ def main():
                                 trace_f.write(f"[{time.strftime('%Y-%m-%d %H:%M:%S')}] Intentando lanzar start.bat con Popen y DETACHED_PROCESS/CREATE_NEW_CONSOLE.\n")
 
                             # Usar Popen para más control sobre la creación del proceso
+                            # Intentar con la ruta completa al script
+                            full_script_path = str(script_to_run.resolve())
+                            with open(trace_log_file_path, "a", encoding='utf-8') as trace_f:
+                                trace_f.write(f"[{time.strftime('%Y-%m-%d %H:%M:%S')}] Usando ruta completa para Popen: {full_script_path}.\n")
+
                             process = subprocess.Popen(
-                                ['cmd', '/c', script_to_run.name],
-                                cwd=str(script_to_run.parent),
-                                shell=False, # shell=False es más seguro con listas de argumentos
+                                ['cmd', '/c', full_script_path], # Usar ruta completa
+                                cwd=str(script_to_run.parent), # Mantener CWD por si start.bat depende de él para otros archivos
+                                shell=False,
                                 creationflags=subprocess.DETACHED_PROCESS | subprocess.CREATE_NEW_CONSOLE
-                                # stdout, stderr, text, encoding, errors eliminados para simplificar la llamada con DETACHED_PROCESS
-                                # y evitar WinError 87. La salida de start.bat se revisará por sus propios logs
-                                # o por la ventana de consola que se abra.
                             )
 
                             with open(trace_log_file_path, "a", encoding='utf-8') as trace_f:
-                                trace_f.write(f"[{time.strftime('%Y-%m-%d %H:%M:%S')}] start.bat lanzado con Popen (sin captura de stdout/stderr directa). PID (si está disponible): {process.pid}.\n")
+                                trace_f.write(f"[{time.strftime('%Y-%m-%d %H:%M:%S')}] start.bat lanzado con Popen (ruta completa, sin captura stdout/stderr directa). PID (si está disponible): {process.pid}.\n")
                                 trace_f.write(f"[{time.strftime('%Y-%m-%d %H:%M:%S')}] setup.py continuará y finalizará. Revisa si apareció una nueva ventana para start.bat.\n")
 
                             # stdout, stderr = process.communicate(timeout=10) # Podríamos intentar un communicate con timeout


### PR DESCRIPTION
Modifies the Popen call in setup.py to use the full absolute path to scripts/start.bat (via script_to_run.resolve()) instead of just the script name, in an attempt to resolve the persistent "[WinError 87] El parámetro no es correcto" when launching the script in a new console window.