### PR TITLE
Fix: Correct JSX syntax in SettingsPage.jsx

### DIFF
--- a/manus-frontend/src/pages/SettingsPage.jsx
+++ b/manus-frontend/src/pages/SettingsPage.jsx
@@ -289,7 +289,7 @@ export default function SettingsPage() {
           <TabsTrigger value="appearance">Apariencia</TabsTrigger>
           <TabsTrigger value="privacy">Privacidad</TabsTrigger>
           <TabsTrigger value="api">API Keys</TabsTrigger>
-        </Tabs>
+        </TabsList>
 
         {/* Profile Tab */}
         <TabsContent value="profile" className="space-y-6">


### PR DESCRIPTION
Resolved a mismatched closing tag for TabsList, which was causing a build failure. The tag was incorrectly </Tabs> and has been changed to </TabsList>.