### PR TITLE
fix(docker): correct frontend build context in docker-compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -47,7 +47,7 @@ services:
   # Frontend React
   frontend:
     build:
-      context: ./frontend
+      context: ./manus-frontend
       dockerfile: Dockerfile
     container_name: manus-frontend
     environment:


### PR DESCRIPTION
The frontend service in docker-compose.yml was using `./frontend` as the build context, but the actual frontend code and Dockerfile are in `./manus-frontend`.

This commit updates the context path to `./manus-frontend` to allow Docker to correctly find the Dockerfile and build the frontend image.