### PR TITLE
fix(frontend): resolve missing toaster component in build

### DIFF
--- a/manus-frontend/src/App.jsx
+++ b/manus-frontend/src/App.jsx
@@ -1,6 +1,6 @@
 import { useState, useEffect } from 'react'
 import { BrowserRouter as Router, Routes, Route, Navigate } from 'react-router-dom'
-import { Toaster } from '@/components/ui/toaster'
+import { Toaster } from '@/components/ui/sonner' # Corrected path
 import { ThemeProvider } from '@/components/theme-provider'
 import { AuthProvider } from '@/contexts/AuthContext'
 import { SocketProvider } from '@/contexts/SocketContext'


### PR DESCRIPTION
The frontend Docker build was failing because `App.jsx` was trying to import `Toaster` from `'@/components/ui/toaster'`, but the actual component file is `sonner.jsx`.

This commit corrects the import path in `manus-frontend/src/App.jsx` to `'@/components/ui/sonner'`, allowing Vite to find the component during the build process.