### PR TITLE
fix(frontend): correct syntax error in App.jsx

### DIFF
--- a/manus-frontend/src/App.jsx
+++ b/manus-frontend/src/App.jsx
@@ -1,6 +1,6 @@
 import { useState, useEffect } from 'react'
 import { BrowserRouter as Router, Routes, Route, Navigate } from 'react-router-dom'
-import { Toaster } from '@/components/ui/sonner' # Corrected path
+import { Toaster } from '@/components/ui/sonner'
 import { ThemeProvider } from '@/components/theme-provider'
 import { AuthProvider } from '@/contexts/AuthContext'
 import { SocketProvider } from '@/contexts/SocketContext'


### PR DESCRIPTION
Removes an invalid Python-style comment (`#`) from an import statement in `manus-frontend/src/App.jsx` that was causing a syntax error during the Vite build process.

The import for `Toaster` from `sonner` is now syntactically correct.