### PR TITLE
fix(frontend): add missing next-themes dependency

### DIFF
--- a/manus-frontend/package.json
+++ b/manus-frontend/package.json
@@ -21,7 +21,8 @@
     "react-router-dom": "^6.20.1",
     "socket.io-client": "^4.7.4",
     "tailwind-merge": "^2.0.0",
-    "tailwindcss-animate": "^1.0.7"
+    "tailwindcss-animate": "^1.0.7",
+    "next-themes": "^0.3.0"
   },
   "devDependencies": {
     "@types/react": "^18.2.37",


### PR DESCRIPTION
The `sonner.jsx` component (used for Toaster) requires `next-themes` to function correctly, but this package was missing from the frontend dependencies.

This commit adds `next-themes` to `manus-frontend/package.json` to resolve the import error during the Vite build process.