### PR TITLE
feat(frontend): add sonner dependency

### DIFF
--- a/manus-frontend/package.json
+++ b/manus-frontend/package.json
@@ -22,7 +22,8 @@
     "socket.io-client": "^4.7.4",
     "tailwind-merge": "^2.0.0",
     "tailwindcss-animate": "^1.0.7",
-    "next-themes": "^0.3.0"
+    "next-themes": "^0.3.0",
+    "sonner": "^1.5.0"
   },
   "devDependencies": {
     "@types/react": "^18.2.37",


### PR DESCRIPTION
Adds `sonner` as a dependency to `manus-frontend/package.json`. This package is required by the `sonner.jsx` component (used for Toaster) and was causing a build failure due to being unresolved.