### PR TITLE
fix(frontend): remove incorrect tailwindcss import from App.css

### DIFF
--- a/manus-frontend/src/App.css
+++ b/manus-frontend/src/App.css
@@ -1,4 +1,3 @@
-@import "tailwindcss";
 @import "tw-animate-css";
 
 @custom-variant dark (&:is(.dark *));


### PR DESCRIPTION
The file `manus-frontend/src/App.css` contained an `@import "tailwindcss";` directive. This was causing an error during the build process because `postcss-import` (or a similar mechanism) was attempting to parse a JavaScript file from the `tailwindcss` node module as if it were a CSS file.

Tailwind's core styles are already correctly included via `@tailwind` directives in `index.css`, which is imported in `main.jsx`.

This commit removes the redundant and problematic import from `App.css` to resolve the PostCSS build error.