### PR TITLE
fix(frontend): remove incorrect tw-animate-css import from App.css

### DIFF
--- a/manus-frontend/src/App.css
+++ b/manus-frontend/src/App.css
@@ -1,4 +1,3 @@
-@import "tw-animate-css";
 
 @custom-variant dark (&:is(.dark *));
 


### PR DESCRIPTION
The file `manus-frontend/src/App.css` contained an `@import "tw-animate-css";` directive. This was causing an error during the build process because PostCSS could not find a file or package named `tw-animate-css`.

The `tailwindcss-animate` package is a Tailwind plugin and should be configured in `tailwind.config.js` if its utilities are desired. Importing it directly as a CSS file named `tw-animate-css` is incorrect.

This commit removes the problematic import to resolve the build error.