### PR TITLE
fix(frontend): consolidate @layer base styles into index.css

### DIFF
--- a/manus-frontend/src/App.css
+++ b/manus-frontend/src/App.css
@@ -107,12 +107,3 @@
   --sidebar-border: oklch(1 0 0 / 10%);
   --sidebar-ring: oklch(0.556 0 0);
 }
-
-@layer base {
-  * {
-    @apply border-border outline-ring/50;
-  }
-  body {
-    @apply bg-background text-foreground;
-  }
-}

--- a/manus-frontend/src/index.css
+++ b/manus-frontend/src/index.css
@@ -3,3 +3,12 @@
 @tailwind utilities;
 
 /* Your custom CSS can go here */
+
+@layer base {
+  * {
+    @apply border-border outline-ring/50;
+  }
+  body {
+    @apply bg-background text-foreground;
+  }
+}


### PR DESCRIPTION
The `@layer base` directive in `App.css` was causing a build error because Tailwind expects the corresponding `@tailwind base` directive to be present in the same CSS context.

This commit moves the custom base styles from the `@layer base` block in `App.css` to `index.css`, which already contains the `@tailwind base` directive. This ensures that custom base styles are correctly processed by Tailwind CSS.