### PR TITLE
feat(frontend): configure tailwind theme to use CSS variables

### DIFF
--- a/manus-frontend/tailwind.config.js
+++ b/manus-frontend/tailwind.config.js
@@ -4,8 +4,71 @@ export default {
     "./index.html",
     "./src/**/*.{js,ts,jsx,tsx}",
   ],
+  darkMode: ["class"], // Recommended for Shadcn UI / next-themes
   theme: {
-    extend: {},
+    container: { // Recommended by Shadcn UI
+      center: true,
+      padding: "2rem",
+      screens: {
+        "2xl": "1400px",
+      },
+    },
+    extend: {
+      colors: {
+        border: "oklch(var(--border))",
+        input: "oklch(var(--input))",
+        ring: "oklch(var(--ring))",
+        background: "oklch(var(--background))",
+        foreground: "oklch(var(--foreground))",
+        primary: {
+          DEFAULT: "oklch(var(--primary))",
+          foreground: "oklch(var(--primary-foreground))",
+        },
+        secondary: {
+          DEFAULT: "oklch(var(--secondary))",
+          foreground: "oklch(var(--secondary-foreground))",
+        },
+        destructive: {
+          DEFAULT: "oklch(var(--destructive))",
+          foreground: "oklch(var(--destructive-foreground))", // Assuming a --destructive-foreground exists or is white/black
+        },
+        muted: {
+          DEFAULT: "oklch(var(--muted))",
+          foreground: "oklch(var(--muted-foreground))",
+        },
+        accent: {
+          DEFAULT: "oklch(var(--accent))",
+          foreground: "oklch(var(--accent-foreground))",
+        },
+        popover: {
+          DEFAULT: "oklch(var(--popover))",
+          foreground: "oklch(var(--popover-foreground))",
+        },
+        card: {
+          DEFAULT: "oklch(var(--card))",
+          foreground: "oklch(var(--card-foreground))",
+        },
+      },
+      borderRadius: {
+        lg: "var(--radius)",
+        md: "calc(var(--radius) - 2px)",
+        sm: "calc(var(--radius) - 4px)",
+      },
+      keyframes: { // From Shadcn UI
+        "accordion-down": {
+          from: { height: "0" },
+          to: { height: "var(--radix-accordion-content-height)" },
+        },
+        "accordion-up": {
+          from: { height: "var(--radix-accordion-content-height)" },
+          to: { height: "0" },
+        },
+      },
+      animation: { // From Shadcn UI
+        "accordion-down": "accordion-down 0.2s ease-out",
+        "accordion-up": "accordion-up 0.2s ease-out",
+      },
+    },
   },
-  plugins: [],
+  plugins: [require("tailwindcss-animate")],
 }


### PR DESCRIPTION
Updates `tailwind.config.js` to map CSS custom properties (like `--background`, `--foreground`, `--border`, `--primary`, `--radius`, etc.) to Tailwind's theme configuration.

This allows Tailwind to generate utility classes such as `bg-background`, `text-foreground`, `border-border`, and `rounded-lg` based on these CSS variables, resolving issues where `@apply` could not find these classes.

Also includes:
- `darkMode: ["class"]`
- Basic container configuration
- Standard keyframes and animations for accordions (common with Shadcn UI)
- Adds `tailwindcss-animate` to the plugins array.