### PR TITLE
fix(frontend): correct @apply syntax for outline opacity

### DIFF
--- a/manus-frontend/src/index.css
+++ b/manus-frontend/src/index.css
@@ -6,7 +6,7 @@
 
 @layer base {
   * {
-    @apply border-border outline-ring/50;
+    @apply border-border outline-ring opacity-50;
   }
   body {
     @apply bg-background text-foreground;


### PR DESCRIPTION
Changes the `@apply` directive in `index.css` from `outline-ring/50` to `outline-ring opacity-50`.

The `/50` syntax for opacity is generally used directly with color utilities (e.g., `bg-blue-500/50`) and not as a suffix to an arbitrary class name in `@apply`. The `opacity-50` utility class is the standard way to apply opacity in this context.