### PR TITLE
fix(frontend): correct import for toast function in SocketContext

### DIFF
--- a/manus-frontend/src/contexts/SocketContext.jsx
+++ b/manus-frontend/src/contexts/SocketContext.jsx
@@ -1,7 +1,7 @@
 import { createContext, useContext, useEffect, useState } from 'react'
 import { io } from 'socket.io-client'
 import { useAuth } from './AuthContext'
-import { toast } from '@/hooks/use-toast'
+import { toast } from 'sonner' // Corrected import
 
 const SocketContext = createContext({})
 


### PR DESCRIPTION
`SocketContext.jsx` was attempting to import a `toast` function from a non-existent custom hook at `@/hooks/use-toast`.

The `toast` function is provided directly by the `sonner` library, which is used for displaying toast notifications.

This commit changes the import statement in `SocketContext.jsx` to `import { toast } from 'sonner';`, resolving the module not found error during the build.