### PR TITLE
fix(frontend): export AuthContext from AuthContext.jsx

### DIFF
--- a/manus-frontend/src/contexts/AuthContext.jsx
+++ b/manus-frontend/src/contexts/AuthContext.jsx
@@ -1,7 +1,7 @@
 import { createContext, useContext, useState, useEffect } from 'react'
 import { authService } from '@/services/authService'
 
-const AuthContext = createContext({})
+export const AuthContext = createContext({}) // Added export
 
 export const useAuth = () => {
   const context = useContext(AuthContext)


### PR DESCRIPTION
The `AuthContext` object, created by `createContext`, was not being exported from `AuthContext.jsx`. This caused an import error in `hooks/useAuth.js`, which relies on this context.

This commit adds the `export` keyword to `AuthContext` to make it available for named imports, resolving the build failure.