### PR TITLE
fix(frontend): use Container icon for Docker in ToolsPage

### DIFF
--- a/manus-frontend/src/pages/ToolsPage.jsx
+++ b/manus-frontend/src/pages/ToolsPage.jsx
@@ -37,7 +37,7 @@ import {
   XCircle,
   AlertTriangle,
   ExternalLink,
-  Docker
+  Container // Changed from Docker
 } from 'lucide-react'
 
 const toolCategories = {
@@ -546,7 +546,7 @@ export default function ToolsPage() {
                         <span>{tool.name}</span>
                         {tool.official && (
                           <Badge variant="outline" className="text-xs">
-                            <Docker className="w-3 h-3 mr-1" />
+                            <Container className="w-3 h-3 mr-1" /> {/* Changed from Docker */}
                             Oficial
                           </Badge>
                         )}


### PR DESCRIPTION
Replaces the attempt to import a non-existent `Docker` icon from `lucide-react` with the `Container` icon in `manus-frontend/src/pages/ToolsPage.jsx`.

The `lucide-react` library does not export an icon named `Docker`. The `Container` icon is a suitable replacement for representing Docker or containerized tools.

This change corrects both the import statement and the component usage in the JSX, resolving the build error.