### PR TITLE
feat(debug): add extensive logging for auth and rendering flow

### DIFF
--- a/manus-frontend/src/App.jsx
+++ b/manus-frontend/src/App.jsx
@@ -28,7 +28,10 @@ function AppContent() {
   const { user, loading } = useAuth()
   const [sidebarOpen, setSidebarOpen] = useState(true)
 
+  console.log('[AppContent] Rendering. Auth state:', { user, loading });
+
   if (loading) {
+    console.log('[AppContent] Auth loading is true, rendering spinner.');
     return (
       <div className="flex items-center justify-center min-h-screen">
         <div className="animate-spin rounded-full h-32 w-32 border-b-2 border-primary"></div>
@@ -37,9 +40,11 @@ function AppContent() {
   }
 
   if (!user) {
+    console.log('[AppContent] User not authenticated (or user is null), rendering LoginPage.');
     return <LoginPage />
   }
 
+  console.log('[AppContent] User authenticated, rendering main app layout.');
   return (
     <div className="flex h-screen bg-background">
       <Sidebar open={sidebarOpen} onToggle={() => setSidebarOpen(!sidebarOpen)} />

--- a/manus-frontend/src/contexts/AuthContext.jsx
+++ b/manus-frontend/src/contexts/AuthContext.jsx
@@ -14,25 +14,37 @@ export const useAuth = () => {
 export const AuthProvider = ({ children }) => {
   const [user, setUser] = useState(null)
   const [loading, setLoading] = useState(true)
-  const [token, setToken] = useState(localStorage.getItem('auth_token'))
+  const initialToken = localStorage.getItem('auth_token');
+  const [token, setToken] = useState(initialToken)
+  console.log('[AuthContext] Initial token from localStorage:', initialToken);
 
   useEffect(() => {
+    console.log('[AuthContext] useEffect triggered. Current token state:', token);
     const initAuth = async () => {
+      console.log('[AuthContext] initAuth started.');
       if (token) {
+        console.log('[AuthContext] Token exists, attempting to get current user.');
         try {
           const userData = await authService.getCurrentUser()
+          console.log('[AuthContext] getCurrentUser success:', userData);
           setUser(userData)
         } catch (error) {
-          console.error('Auth initialization failed:', error)
+          console.error('[AuthContext] Auth initialization failed (getCurrentUser error):', error)
           localStorage.removeItem('auth_token')
-          setToken(null)
+          setToken(null) // This will re-trigger useEffect
+          console.log('[AuthContext] Token removed due to error.');
         }
+      } else {
+        console.log('[AuthContext] No token, skipping getCurrentUser.');
       }
+      console.log('[AuthContext] Setting loading to false.');
       setLoading(false)
     }
 
     initAuth()
   }, [token])
+
+  console.log('[AuthContext] Rendering AuthProvider. State: ', { user, token, loading });
 
   const login = async (credentials) => {
     try {

--- a/manus-frontend/src/pages/LoginPage.jsx
+++ b/manus-frontend/src/pages/LoginPage.jsx
@@ -9,6 +9,7 @@ import { useAuth } from '@/hooks/useAuth'
 import { Zap, Bot, Loader2, Eye, EyeOff } from 'lucide-react'
 
 export default function LoginPage() {
+  console.log('[LoginPage] Component function executing / mounting.');
   const { login, register } = useAuth()
   const [loading, setLoading] = useState(false)
   const [error, setError] = useState('')
@@ -97,6 +98,7 @@ export default function LoginPage() {
     setError('')
   }
 
+  console.log('[LoginPage] About to return JSX. Current local state:', { loading, error, activeTab });
   return (
     <div className="min-h-screen flex items-center justify-center bg-gradient-to-br from-background via-background to-accent/20 p-4">
       <div className="w-full max-w-md space-y-8">


### PR DESCRIPTION
Adds detailed console.log statements to key frontend components to trace the application startup, authentication process, and rendering logic:

- `AuthContext.jsx`: Logs initial token, steps within `initAuth` (token presence, user fetching success/failure, loading state changes), and the final context values provided.
- `App.jsx` (`AppContent`): Logs the auth state received (`user`, `loading`) and which main component branch is being rendered (spinner, LoginPage, or main app layout).
- `LoginPage.jsx`: Logs when the component function is executed/mounted and just before it returns its JSX, along with its local state.

These logs are intended to help diagnose issues where the page might appear blank or render incompletely without clear console errors.