### PR TITLE
Fix: Remove global opacity-50 causing blank page

### DIFF
--- a/manus-frontend/src/index.css
+++ b/manus-frontend/src/index.css
@@ -75,7 +75,7 @@
 
 @layer base {
   * {
-    @apply border-border outline-ring opacity-50;
+    @apply border-border outline-ring;
   }
   body {
     @apply bg-background text-foreground;


### PR DESCRIPTION
The global style `* { @apply opacity-50; }` in `index.css` was making all elements semi-transparent, leading to the page appearing blank. This commit removes the offending opacity rule.