### PR TITLE
Fix: Allow unsafe Werkzeug for development/testing

### DIFF
--- a/backend/src/main.py
+++ b/backend/src/main.py
@@ -172,5 +172,5 @@ if __name__ == '__main__':
     logger.info(f"Upload folder: {app.config['UPLOAD_FOLDER']}")
     
     # Ejecutar con SocketIO
-    socketio.run(app, host='0.0.0.0', port=5000, debug=app.config['DEBUG'])
+    socketio.run(app, host='0.0.0.0', port=5000, debug=app.config['DEBUG'], allow_unsafe_werkzeug=True)
 


### PR DESCRIPTION
Added `allow_unsafe_werkzeug=True` to the `socketio.run()` call in `backend/src/main.py`.

This change allows the Werkzeug development server to run even if FLASK_ENV is set to 'production', which would normally prevent it. This is a temporary workaround to facilitate further testing and debugging once the Supabase database schema issues are resolved by the user.

For actual production deployments, a production-grade WSGI server (e.g., Gunicorn with eventlet/gevent) should be used instead.