### PR TITLE
feat: Enhance Winget installation process for Supabase CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,10 @@ Este proyecto utiliza Supabase como backend de base de datos en producción o pa
     3.  **Archivo `supabase_init.sql`:** Asegúrate de que el archivo `supabase_init.sql` (que contiene el esquema inicial de la base de datos) esté presente en el directorio raíz del proyecto.
 
     **¿Qué hace el script `supabase_setup.py`?**
-    *   Verifica si la Supabase CLI está instalada. Si estás en Windows y no lo está, te ofrecerá instalarla con `winget`.
+    *   Verifica si la Supabase CLI está instalada.
+        *   Si estás en Windows y no se encuentra, el script primero intentará actualizar las fuentes de `winget` (`winget source update --now`).
+        *   Luego, buscará el paquete `supabase.cli` usando `winget search supabase.cli`.
+        *   Si se encuentra (o como fallback), te ofrecerá intentar instalar/actualizar la CLI automáticamente usando `winget install supabase.cli`.
     *   Verifica que hayas iniciado sesión en la Supabase CLI.
     *   Se asegura de que el directorio actual esté configurado como un proyecto Supabase local (ejecutando `supabase init` si es necesario y lo apruebas).
     *   Te pide el `PROJECT_REF` de tu proyecto Supabase (si no puede encontrarlo en `supabase/config.toml`).


### PR DESCRIPTION
Improved `supabase_setup.py` to make the Supabase CLI installation process on Windows more robust:
- The script now attempts to run `winget source update --now` before other Winget commands.
- It then runs `winget search supabase.cli` to verify package availability and potentially get the exact ID.
- Proceeds to `winget install` using the found or default package ID.
- Includes more detailed feedback to the user during these Winget operations.

Updated `README.md` to reflect these more proactive steps the script takes for Winget-based installation on Windows.