### PR TITLE
feat: Implement sequential multi-installer attempt for Supabase CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,11 +60,12 @@ Este proyecto utiliza Supabase como backend de base de datos en producción o pa
 
     **¿Qué hace el script `supabase_setup.py`?**
     *   Verifica si la Supabase CLI está instalada.
-        *   Si estás en Windows y no se encuentra, el script intentará:
-            1.  Actualizar las fuentes de `winget` (`winget source update`).
-            2.  Buscar el paquete `Supabase.SupabaseCLI` usando `winget search Supabase.SupabaseCLI`.
-            3.  Si la búsqueda es exitosa, te ofrecerá instalar la CLI usando `winget install Supabase.SupabaseCLI`. El script verifica la salida de Winget para confirmar una instalación exitosa (buscando "instalado correctamente" o "successfully installed").
-    *   Verifica que hayas iniciado sesión en la Supabase CLI.
+        *   Si no está instalada, te preguntará si deseas que intente una instalación automática.
+        *   Si aceptas, el script intentará los siguientes métodos en secuencia (principalmente para Windows, NPM también es multiplataforma):
+            1.  **Winget (Windows):** Intenta actualizar fuentes, buscar `Supabase.SupabaseCLI` e instalarlo. Verifica el éxito examinando la salida del comando.
+            2.  **Scoop (Windows/Otros):** Si Winget falla o no aplica, intenta instalar `supabase` usando `scoop install supabase`.
+            3.  **NPM (Multiplataforma):** Si los métodos anteriores fallan, intenta instalar `supabase` globalmente usando `npm install supabase --global`.
+    *   Verifica que hayas iniciado sesión en la Supabase CLI (una vez que la CLI está disponible).
     *   Se asegura de que el directorio actual esté configurado como un proyecto Supabase local (ejecutando `supabase init` si es necesario y lo apruebas).
     *   Te pide el `PROJECT_REF` de tu proyecto Supabase (si no puede encontrarlo en `supabase/config.toml`).
     *   Vincula tu proyecto local con tu proyecto Supabase remoto usando `supabase link`.


### PR DESCRIPTION
Updated `supabase_setup.py` to sequentially attempt Supabase CLI installation using Winget (Windows-only), Scoop, and then NPM if the CLI is not found and the user opts for automatic installation.

Key changes:
- Added a single user prompt to attempt automatic installation.
- Implemented checks for Winget, Scoop, and NPM availability.
- Executes installation commands for each available method in sequence until one succeeds or all have been attempted.
- Uses `Supabase.SupabaseCLI` as the package ID for Winget.
- Includes `winget source update` before attempting Winget search/install.
- Verifies installation success by checking `supabase --version` after each attempt.
- Provides informative messages throughout the process.
- Updated `run_command` to handle encoding for better cross-platform output.

Updated `README.md` to describe the new sequential installation logic and prerequisites (Winget, Scoop, or Node.js/npm should be pre-installed for the script to use them).