### PR TITLE
fix: Correct control flow for direct GitHub download

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,10 +61,13 @@ Este proyecto utiliza Supabase como backend de base de datos en producción o pa
     **¿Qué hace el script `supabase_setup.py`?**
     *   Verifica si la Supabase CLI está instalada.
         *   Si no está instalada, te preguntará si deseas que intente una instalación automática.
-        *   Si aceptas, el script intentará los siguientes métodos en secuencia (principalmente para Windows, NPM también es multiplataforma):
-            1.  **Winget (Windows):** Intenta actualizar fuentes, buscar `Supabase.SupabaseCLI` e instalarlo. Verifica el éxito examinando la salida del comando.
-            2.  **Scoop (Windows/Otros):** Si Winget falla o no aplica, intenta instalar `supabase` usando `scoop install supabase`.
-            3.  **NPM (Multiplataforma):** Si los métodos anteriores fallan, intenta instalar `supabase` globalmente usando `npm install supabase --global`.
+        *   Si aceptas, el script intentará los siguientes métodos en secuencia:
+            1.  **Winget (Solo Windows):** Intenta actualizar fuentes, buscar `Supabase.SupabaseCLI` e instalarlo. Verifica el éxito.
+            2.  **Scoop (Solo Windows):** Si Winget falla o no está disponible, el script verificará si Scoop está instalado.
+                *   Si Scoop no está instalado, te preguntará si deseas que intente instalarlo (esto implica cambiar políticas de ejecución de PowerShell y ejecutar un script de internet, con las debidas advertencias).
+                *   Si Scoop está (o se instala exitosamente), intentará `scoop install supabase`.
+            3.  **NPM (Multiplataforma):** Si los métodos anteriores fallan o no aplican, y si NPM está disponible, intentará instalar `supabase` globalmente (`npm install supabase --global`). El script no instalará Node.js/NPM.
+            4.  **Descarga Directa desde GitHub (Multiplataforma):** Como último recurso, si todos los métodos anteriores fallan, el script ofrecerá descargar la última versión de Supabase CLI directamente desde sus releases en GitHub. La extraerá y la colocará en un subdirectorio (`supabase_cli_installed_by_script` o similar en tu perfil de usuario). En este caso, **deberás añadir manualmente este directorio a tu variable de entorno PATH** y reiniciar tu terminal.
     *   Verifica que hayas iniciado sesión en la Supabase CLI (una vez que la CLI está disponible).
     *   Se asegura de que el directorio actual esté configurado como un proyecto Supabase local (ejecutando `supabase init` si es necesario y lo apruebas).
     *   Te pide el `PROJECT_REF` de tu proyecto Supabase (si no puede encontrarlo en `supabase/config.toml`).

--- a/supabase_setup.py
+++ b/supabase_setup.py
@@ -4,6 +4,11 @@ import subprocess
 import datetime
 import configparser # Para leer el project_id de config.toml
 import platform # Para detectar el sistema operativo
+import json
+import urllib.request
+import zipfile
+import tarfile
+import stat # Para os.chmod
 
 # Constantes
 SUPABASE_DIR = "supabase"
@@ -28,19 +33,17 @@ def print_info(message):
 def print_warning(message):
     print(f"\n⚠️ WARNING: {message}")
 
-# Nueva función run_command proporcionada por el usuario
 def run_command(command_list, timeout=60, check=True, suppress_output=False):
     """Ejecuta un comando de subprocess de forma segura y devuelve (éxito, stdout, stderr)."""
     try:
-        # Añadir encoding y errors='replace' para sistemas Windows
         process = subprocess.run(
             command_list,
             capture_output=True,
             text=True,
             check=check,
             timeout=timeout,
-            encoding='utf-8', # Especificar utf-8
-            errors='replace'  # Reemplazar caracteres que no se puedan decodificar
+            encoding='utf-8',
+            errors='replace'
         )
         if not suppress_output:
             if process.stdout and process.stdout.strip():
@@ -49,7 +52,7 @@ def run_command(command_list, timeout=60, check=True, suppress_output=False):
                 print_warning(f"Salida de error (puede ser informativa) de {' '.join(command_list)}:\n{process.stderr.strip()}")
         return True, process.stdout.strip(), process.stderr.strip()
     except subprocess.CalledProcessError as e:
-        if not suppress_output: # Solo imprimir si no se suprime la salida
+        if not suppress_output:
             print_error(f"Error al ejecutar: {' '.join(command_list)}")
             if e.stdout and e.stdout.strip(): print_info(f"Salida (stdout) del error: {e.stdout.strip()}")
             if e.stderr and e.stderr.strip(): print_error(f"Salida (stderr) del error: {e.stderr.strip()}")
@@ -62,12 +65,11 @@ def run_command(command_list, timeout=60, check=True, suppress_output=False):
         if not suppress_output:
             print_error(f"El comando '{' '.join(command_list)}' tardó demasiado en responder (timeout: {timeout}s).")
         return False, "", f"Timeout ({timeout}s) para el comando: {' '.join(command_list)}"
-    except Exception as e: # Captura otras excepciones de subprocess o generales
+    except Exception as e:
         if not suppress_output:
             print_error(f"Error inesperado al ejecutar {' '.join(command_list)}: {e}")
         return False, "", str(e)
 
-# Nueva función check_supabase_cli con lógica secuencial de instalación
 def check_supabase_cli():
     print_info("Verificando Supabase CLI...")
     success, initial_stdout, initial_stderr = run_command(["supabase", "--version"], suppress_output=True)
@@ -77,7 +79,6 @@ def check_supabase_cli():
 
     print_warning("Supabase CLI no está instalada o no se encuentra en el PATH.")
 
-    # Preguntar una sola vez si se desea intentar la instalación automática
     attempt_auto_install = input("¿Deseas que el script intente instalar Supabase CLI automáticamente? (s/N): ").strip().lower()
     if attempt_auto_install != 's':
         print_info("Instalación automática omitida por el usuario.")
@@ -85,74 +86,99 @@ def check_supabase_cli():
         return False
 
     # --- Secuencia de intentos de instalación ---
-
     # 1. WINGET (Solo Windows)
     if platform.system() == "Windows":
         print_header("Intentando instalación con Winget (Windows)")
         winget_available, _, _ = run_command(["winget", "--version"], suppress_output=True)
         if winget_available:
             print_info("Winget detectado. Intentando actualizar fuentes...")
-            run_command(["winget", "source", "update"], timeout=180, check=False) # Salida manejada por run_command
+            run_command(["winget", "source", "update"], timeout=180, check=False)
             print_info("Intento de actualización de fuentes de Winget completado.")
 
             package_id = "Supabase.SupabaseCLI"
             print_info(f"Buscando el paquete '{package_id}' con Winget...")
             search_cmd = ["winget", "search", package_id, "--source", "winget", "--accept-source-agreements"]
-            search_success, search_stdout, search_stderr = run_command(search_cmd, timeout=120, check=False)
+            search_success, search_stdout, search_stderr_search = run_command(search_cmd, timeout=120, check=False)
 
             if search_success and package_id.lower() in search_stdout.lower() and "No se encontró ningún paquete" not in search_stdout :
                 print_success(f"Paquete '{package_id}' encontrado vía Winget.")
                 print_info(f"Intentando instalar '{package_id}' con Winget...")
                 winget_cmd = ["winget", "install", package_id, "--source", "winget", "--accept-package-agreements", "--accept-source-agreements"]
-                install_success, install_stdout, _ = run_command(winget_cmd, timeout=300, check=False)
+                install_success, install_stdout, install_stderr_install = run_command(winget_cmd, timeout=300, check=False)
 
-                if install_success and ("instalado correctamente" in install_stdout.lower() or "successfully installed" in install_stdout.lower()):
+                if install_success and \
+                   ("instalado correctamente" in install_stdout.lower() or "successfully installed" in install_stdout.lower()) and \
+                   "No se encontró ningún paquete" not in install_stdout and \
+                   "No se encontró ningún paquete" not in install_stderr_install:
                     print_success("Winget reportó instalación exitosa. Verificando...")
                     if run_command(["supabase", "--version"], suppress_output=True)[0]:
                         print_success("¡Supabase CLI instalada y verificada exitosamente vía Winget!")
                         print_warning("Es posible que necesites REINICIAR TU TERMINAL (o VSCode) para que el PATH se actualice.")
                         return True
                     else:
-                        print_error("Supabase CLI no se encuentra después de la instalación con Winget, aunque Winget indicó éxito.")
+                        print_error("Supabase CLI no se encuentra después de la instalación con Winget (aunque Winget indicó éxito).")
                 else:
-                    print_error("Falló la instalación con Winget o no se confirmó el éxito.")
+                    print_error("Falló la instalación con Winget o no se confirmó el éxito en la salida.")
             else:
-                print_warning(f"Winget no pudo encontrar/confirmar el paquete '{package_id}'. (Search stdout: '{search_stdout}', stderr: '{search_stderr}')")
+                print_warning(f"Winget no pudo encontrar/confirmar el paquete '{package_id}'. (Search stdout: '{search_stdout}', stderr: '{search_stderr_search}')")
         else:
             print_info("Winget no está disponible en este sistema.")
 
-    # 2. SCOOP (Principalmente Windows, pero puede estar en otros SO si el usuario lo instaló)
-    # No preguntaremos de nuevo, si el usuario aceptó la instalación automática, probamos todos los métodos.
-    print_header("Intentando instalación con Scoop")
-    scoop_available, _, _ = run_command(["scoop", "--version"], suppress_output=True)
-    if scoop_available:
-        print_info("Scoop detectado. Intentando instalar 'supabase'...")
-        # Scoop puede necesitar que el bucket 'extras' esté añadido para algunos paquetes.
-        # Por simplicidad, no intentaremos añadir buckets aquí.
-        install_success, _, _ = run_command(["scoop", "install", "supabase"], timeout=300, check=False)
-        if install_success: # Scoop suele ser más directo; si el comando tiene éxito, usualmente está instalado.
-            print_success("Comando 'scoop install supabase' ejecutado. Verificando...")
-            if run_command(["supabase", "--version"], suppress_output=True)[0]:
-                print_success("¡Supabase CLI instalada y verificada exitosamente vía Scoop!")
-                print_warning("Es posible que necesites REINICIAR TU TERMINAL (o VSCode) para que el PATH se actualice.")
-                return True
+    # 2. SCOOP (Solo Windows, con intento de instalación de Scoop)
+    if platform.system() == "Windows":
+        print_header("Intentando instalación con Scoop")
+        scoop_available, _, _ = run_command(["scoop", "--version"], suppress_output=True)
+        if not scoop_available:
+            print_info("Scoop no está disponible en este sistema.")
+            install_scoop_choice = input("¿Deseas que el script intente instalar Scoop? (Esto cambiará tu política de ejecución de PowerShell y ejecutará un script de internet) (s/N): ").strip().lower()
+            if install_scoop_choice == 's':
+                print_info("Intentando instalar Scoop...")
+                ps_command_policy = "Set-ExecutionPolicy RemoteSigned -Scope CurrentUser -Force"
+                ps_command_install = "iex (new-object net.webclient).downloadstring('https://get.scoop.sh')"
+
+                print_warning("Cambiando política de ejecución de PowerShell para CurrentUser a RemoteSigned...")
+                policy_success, _, policy_err = run_command(["powershell", "-Command", ps_command_policy], timeout=60, check=False)
+                if not policy_success:
+                    print_error(f"No se pudo cambiar la política de ejecución de PowerShell. Detalle: {policy_err}")
+                else:
+                    print_success("Política de ejecución de PowerShell actualizada para CurrentUser.")
+                    print_info("Descargando y ejecutando script de instalación de Scoop...")
+                    install_scoop_success, _, scoop_install_err = run_command(["powershell", "-Command", ps_command_install], timeout=300, check=False)
+                    if install_scoop_success:
+                        print_success("Script de instalación de Scoop ejecutado. Verificando Scoop...")
+                        # Es crucial re-chequear la disponibilidad de scoop aquí ANTES de usarlo.
+                        scoop_available, _, _ = run_command(["scoop", "--version"], suppress_output=True)
+                        if scoop_available:
+                            print_success("¡Scoop instalado exitosamente!")
+                        else:
+                            print_error(f"Scoop no se pudo verificar después de la instalación. Error: {scoop_install_err}")
+                    else:
+                        print_error(f"Falló la ejecución del script de instalación de Scoop. Error: {scoop_install_err}")
             else:
-                print_error("Supabase CLI no se encuentra después de la instalación con Scoop.")
-        else:
-            print_error("Falló la instalación con Scoop.")
-    else:
-        print_info("Scoop no está disponible en este sistema.")
+                print_info("Instalación de Scoop omitida por el usuario.")
+
+        if scoop_available: # Si estaba disponible o se instaló y verificó
+            print_info("Intentando instalar 'supabase' con Scoop...")
+            install_success, _, _ = run_command(["scoop", "install", "supabase"], timeout=300, check=False)
+            if install_success:
+                print_success("Comando 'scoop install supabase' ejecutado. Verificando...")
+                if run_command(["supabase", "--version"], suppress_output=True)[0]:
+                    print_success("¡Supabase CLI instalada y verificada exitosamente vía Scoop!")
+                    print_warning("Es posible que necesites REINICIAR TU TERMINAL (o VSCode) para que el PATH se actualice.")
+                    return True
+                else:
+                    print_error("Supabase CLI no se encuentra después de la instalación con Scoop.")
+            else:
+                print_error("Falló la instalación de Supabase CLI con Scoop.")
 
     # 3. NPM (Multiplataforma)
     print_header("Intentando instalación con NPM")
     npm_available, _, _ = run_command(["npm", "--version"], suppress_output=True)
     if npm_available:
         print_info("NPM detectado. Intentando instalar 'supabase' globalmente...")
-        # npm install -g puede requerir permisos de administrador en algunos sistemas.
         install_success, _, _ = run_command(["npm", "install", "supabase", "--global"], timeout=300, check=False)
-        if install_success: # Similar a scoop, si npm -g tiene éxito, suele funcionar.
+        if install_success:
             print_success("Comando 'npm install supabase --global' ejecutado. Verificando...")
-            # La verificación de `supabase --version` puede fallar inmediatamente si el PATH global de npm no está en la sesión actual.
             if run_command(["supabase", "--version"], suppress_output=True)[0]:
                 print_success("¡Supabase CLI instalada y verificada exitosamente vía NPM!")
                 print_warning("Es posible que necesites REINICIAR TU TERMINAL (o VSCode) para que el PATH se actualice.")
@@ -160,18 +186,151 @@ def check_supabase_cli():
             else:
                 print_error("Supabase CLI no se encuentra después de la instalación con NPM.")
                 print_info("Esto es común si el directorio global de paquetes de NPM no está en tu PATH o si la terminal necesita reiniciarse.")
-                print_info("Intenta reiniciar tu terminal o verifica la configuración de tu PATH para los módulos globales de NPM.")
         else:
             print_error("Falló la instalación con NPM.")
     else:
-        print_info("NPM no está disponible en este sistema.")
+        print_info("NPM no está disponible en este sistema. Para usar este método, instala Node.js y NPM.")
 
-    # Si todos los métodos fallaron
-    print_error("Todos los métodos de instalación automática fallaron o no estaban disponibles.")
+    # 4. DESCARGA DIRECTA DESDE GITHUB RELEASES (Multiplataforma)
+    # Esta sección se ejecuta si todos los métodos anteriores fallaron Y el usuario aceptó la instalación automática al principio.
+    print_header("Intentando descarga directa de Supabase CLI desde GitHub")
+    try:
+        print_info("Obteniendo información de la última release de Supabase CLI...")
+        api_url = "https://api.github.com/repos/supabase/cli/releases/latest"
+        # Manejo de errores de red para la API de GitHub
+        try:
+            with urllib.request.urlopen(api_url, timeout=10) as response: # Timeout para la petición
+                release_data = json.loads(response.read().decode())
+        except urllib.error.URLError as e:
+            print_error(f"Error de red al contactar la API de GitHub: {e.reason}")
+            print_info("Por favor, verifica tu conexión a internet.")
+            # No retornar False aquí, para que el mensaje final de error general se muestre
+        except json.JSONDecodeError:
+            print_error("No se pudo decodificar la respuesta de la API de GitHub (formato inesperado).")
+        except Exception as e: # Otro error inesperado
+            print_error(f"Error inesperado al obtener datos de release: {e}")
+        else: # Si no hubo errores en la petición y decodificación JSON
+            assets = release_data.get("assets", [])
+            if not assets:
+                print_error("No se encontraron assets en la última release de GitHub.")
+            else:
+                os_type = platform.system().lower()
+                arch = platform.machine().lower()
+
+                asset_filename_part = ""
+                asset_ext = ""
+                exe_name = "supabase"
+
+                if os_type == "windows":
+                    asset_ext = ".zip"
+                    exe_name = "supabase.exe"
+                    if arch in ["amd64", "x86_64"]: asset_filename_part = "windows-amd64"
+                    elif arch in ["arm64", "aarch64"]: asset_filename_part = "windows-arm64"
+                elif os_type == "linux":
+                    asset_ext = ".tar.gz"
+                    if arch in ["amd64", "x86_64"]: asset_filename_part = "linux-amd64"
+                    elif arch in ["arm64", "aarch64"]: asset_filename_part = "linux-arm64"
+                elif os_type == "darwin":
+                    asset_ext = ".tar.gz"
+                    if arch in ["amd64", "x86_64"]: asset_filename_part = "darwin-amd64"
+                    elif arch in ["arm64", "aarch64"]: asset_filename_part = "darwin-arm64"
+
+                if not asset_filename_part:
+                    print_error(f"Combinación SO/arquitectura no soportada para descarga directa: {os_type}/{arch}")
+                else:
+                    download_url = None
+                    found_asset_name = ""
+                    for asset in assets:
+                        name = asset.get("name", "").lower()
+                        # Los nombres de assets son como: supabase_1.164.0_darwin_arm64.tar.gz
+                        # o supabase_windows_amd64.zip (sin versión en el nombre a veces)
+                        # Necesitamos un match flexible que contenga la parte os-arch y la extensión
+                        if asset_filename_part in name and name.endswith(asset_ext):
+                            download_url = asset.get("browser_download_url")
+                            found_asset_name = name
+                            print_success(f"Asset encontrado para descarga: {found_asset_name}")
+                            break
+
+                    if not download_url:
+                        print_error(f"No se encontró un asset de descarga compatible para {asset_filename_part} en la última release.")
+                    else:
+                        print_info(f"Descargando Supabase CLI desde: {download_url}")
+                        temp_dir = "temp_supabase_cli_download"
+                        os.makedirs(temp_dir, exist_ok=True)
+                        download_path = os.path.join(temp_dir, found_asset_name) # Usar el nombre encontrado
+
+                        try:
+                            urllib.request.urlretrieve(download_url, download_path)
+                            print_success(f"Descargado en: {download_path}")
+
+                            print_info("Extrayendo binario...")
+                            extracted_bin_path = None
+                            if asset_ext == ".zip":
+                                with zipfile.ZipFile(download_path, 'r') as zip_ref:
+                                    for member_info in zip_ref.infolist(): # Usar infolist para verificar si es un archivo
+                                        if member_info.filename.lower().endswith(exe_name.lower()) and not member_info.is_dir():
+                                            zip_ref.extract(member_info, temp_dir)
+                                            extracted_bin_path = os.path.join(temp_dir, member_info.filename)
+                                            break
+                            elif asset_ext == ".tar.gz":
+                                with tarfile.open(download_path, "r:gz") as tar_ref:
+                                    for member_info in tar_ref.getmembers():
+                                        if member_info.name.lower().endswith(exe_name.lower()) and member_info.isfile():
+                                            tar_ref.extract(member_info, temp_dir)
+                                            extracted_bin_path = os.path.join(temp_dir, member_info.name)
+                                            break
+
+                            if not extracted_bin_path or not os.path.exists(extracted_bin_path):
+                                print_error("No se pudo extraer o encontrar el binario de Supabase CLI del archivo descargado.")
+                            else:
+                                print_success(f"Binario extraído en: {extracted_bin_path}")
+
+                                if platform.system() == "Windows":
+                                    install_dir_base = os.environ.get("LOCALAPPDATA", os.path.expanduser("~"))
+                                    install_dir_path = os.path.join(install_dir_base, "Supabase", "CLI")
+                                else: # Linux/macOS
+                                    install_dir_path = os.path.join(os.path.expanduser("~"), ".supabase", "bin")
+
+                                os.makedirs(install_dir_path, exist_ok=True)
+                                final_bin_path = os.path.join(install_dir_path, exe_name)
+
+                                try:
+                                    shutil.move(extracted_bin_path, final_bin_path)
+                                    print_success(f"Supabase CLI movida a: {final_bin_path}")
+                                    if os_type != "windows":
+                                        os.chmod(final_bin_path, os.stat(final_bin_path).st_mode | stat.S_IEXEC | stat.S_IXGRP | stat.S_IXOTH )
+                                        print_info(f"Permisos de ejecución establecidos para {final_bin_path}")
+
+                                    print_warning(f"Supabase CLI ha sido instalada en: {install_dir_path}")
+                                    print_warning(f"DEBES AÑADIR ESTE DIRECTORIO A TU VARIABLE DE ENTORNO PATH MANUALMENTE.")
+                                    print_warning("Después de añadirlo al PATH, reinicia tu terminal/PC para que los cambios surtan efecto.")
+
+                                    print_info(f"Verificando la instalación en {final_bin_path}...")
+                                    if run_command([final_bin_path, "--version"], suppress_output=False)[0]:
+                                        print_success("¡Supabase CLI instalada y verificada exitosamente desde GitHub!")
+                                        print_info(f"Recuerda añadir '{install_dir_path}' a tu PATH.")
+                                        return True
+                                    else:
+                                        print_error("Falló la verificación de Supabase CLI después de la descarga directa.")
+                                except Exception as move_err:
+                                    print_error(f"No se pudo mover el binario a {final_bin_path}: {move_err}")
+                        except urllib.error.URLError as e:
+                             print_error(f"Error de red al descargar el asset: {e.reason}")
+                        except Exception as e:
+                             print_error(f"Error durante la descarga o extracción del asset: {e}")
+                        finally:
+                            if os.path.exists(temp_dir): shutil.rmtree(temp_dir)
+
+    except Exception as e: # Captura errores de la lógica de descarga principal
+        print_error(f"Ocurrió un error general durante el proceso de descarga directa: {e}")
+        if 'temp_dir' in locals() and os.path.exists(temp_dir) and os.path.isdir(temp_dir):
+            shutil.rmtree(temp_dir)
+
+    # Mensaje final si todos los métodos, incluyendo descarga directa, fallaron
+    print_error("Todos los métodos de instalación automática (incluyendo descarga directa) fallaron o fueron omitidos.")
     print_info("Por favor, instala Supabase CLI manualmente: https://supabase.com/docs/guides/cli/getting-started")
     return False
 
-# El resto del archivo supabase_setup.py (desde check_supabase_login hasta el final) permanece igual
 def check_supabase_login():
     print_info("Verificando estado de login en Supabase CLI...")
     success, _, stderr = run_command(["supabase", "projects", "list"], suppress_output=True)
@@ -221,16 +380,13 @@ def get_project_ref():
             if os.path.getsize(CONFIG_FILE_PATH) > 0:
                 config.read(CONFIG_FILE_PATH)
                 project_id = None
-                # Caso 1: [project_id]\nid = "xxx"
                 if 'project_id' in config and 'id' in config['project_id']:
                     project_id = config['project_id']['id']
-                # Caso 2: project_id = "xxx" (sin sección, leído por configparser bajo DEFAULT si no hay otras secciones)
-                # O si está en una sección por defecto. Es más fiable leerlo manualmente si no está en [project_id].
                 if not project_id:
                     with open(CONFIG_FILE_PATH, 'r') as f_config:
                         for line in f_config:
                             line_strip = line.strip()
-                            if line_strip.startswith('project_id'): # Cubre project_id = "xxx" y project_id="xxx"
+                            if line_strip.startswith('project_id'):
                                 parts = line_strip.split('=', 1)
                                 if len(parts) == 2:
                                     project_id = parts[1].strip().replace('"', '').replace("'", "")
@@ -340,3 +496,5 @@ def main():
 
 if __name__ == "__main__":
     main()
+
+[end of supabase_setup.py]


### PR DESCRIPTION
Corrected a SyntaxError and refined the control flow in `check_supabase_cli` within `supabase_setup.py`. The direct download लोगic from GitHub Releases for Supabase CLI now correctly executes as a final fallback method only if:
1. The user initially agrees to attempt automatic installation.
2. All preceding installation methods (Winget, Scoop, NPM) have failed or are not applicable.

Removed the redundant secondary prompt for the direct download, relying on the initial user consent for automatic installation attempts.